### PR TITLE
Add strawpoll deletion functionality

### DIFF
--- a/src/components/Strawpoll.tsx
+++ b/src/components/Strawpoll.tsx
@@ -305,7 +305,7 @@ export default function Strawpoll(props: StrawpollProps) {
           >
             Create manual poll
             </Button>
-          <StrawpollModal open={modalOpen} onChangeOpenState={setOpen} onConfirm={deleteStrawpoll} trigger={deleteButton}></StrawpollModal>
+          <StrawpollModal open={modalOpen} onChangeOpenState={setOpen} onConfirm={deleteStrawpoll} trigger={deleteButton} />
         </Button.Group>
       break;
     case StrawpollStage.Voting:

--- a/src/components/Strawpoll.tsx
+++ b/src/components/Strawpoll.tsx
@@ -68,8 +68,9 @@ export interface StrawpollProps extends RouteComponentProps<URLParameters> {
 
 export interface ModalProps {
   open: boolean,
-  setOpen: Function,
-  onConfirm: Function
+  onChangeOpenState: (open: boolean) => void,
+  onConfirm: Function,
+  trigger: React.ReactElement<Button>
 }
 
 function getNumberOfVotes(option: StrawpollOptionData, medium: StrawpollMedium) {
@@ -87,14 +88,14 @@ function getNumberOfVotes(option: StrawpollOptionData, medium: StrawpollMedium) 
   }
 }
 
-export function StrawpollConfirm(props: ModalProps) {
+export function StrawpollModal(props: ModalProps) {
   const onYesClick = () => {
     props.onConfirm()
-    props.setOpen(false)
+    props.onChangeOpenState(false)
   }
 
   const onNoClick = () => {
-    props.setOpen(false)
+    props.onChangeOpenState(false)
   }
 
   return (
@@ -102,8 +103,9 @@ export function StrawpollConfirm(props: ModalProps) {
       size={"mini"}
       centered={false}
       open={props.open}
-      onClose={() => props.setOpen(false)}
-      onOpen={() => props.setOpen(true)}
+      onClose={() => props.onChangeOpenState(false)}
+      onOpen={() => props.onChangeOpenState(true)}
+      trigger={props.trigger}
     >
       <Modal.Header>Delete strawpoll?</Modal.Header>
       <Modal.Content>
@@ -271,6 +273,15 @@ export default function Strawpoll(props: StrawpollProps) {
 
   switch (stage) {
     case StrawpollStage.Preparing:
+      let deleteButton =        
+        <Button
+        color="red"
+        basic
+        onClick={()=> setOpen(true)}
+      >
+        <Icon name="delete" />Delete Strawpoll
+      </Button>
+      
       buttons =
         <Button.Group fluid>
           <Button
@@ -294,13 +305,7 @@ export default function Strawpoll(props: StrawpollProps) {
           >
             Create manual poll
             </Button>
-          <Button
-            color="red"
-            basic
-            onClick={()=> setOpen(true)}
-          >
-            <Icon name="delete" />Delete Strawpoll
-          </Button>
+          <StrawpollModal open={modalOpen} onChangeOpenState={setOpen} onConfirm={deleteStrawpoll} trigger={deleteButton}></StrawpollModal>
         </Button.Group>
       break;
     case StrawpollStage.Voting:
@@ -360,7 +365,6 @@ export default function Strawpoll(props: StrawpollProps) {
           {optionsTree}
         </List>
         {buttons}
-        <StrawpollConfirm open={modalOpen} setOpen={setOpen} onConfirm={deleteStrawpoll}></StrawpollConfirm>
       </Container>
     );
 }


### PR DESCRIPTION
Adds functionality for deleting strawpolls with a modal that pops up and asks for confirmation. I made a generalised component that returns a modal with a parameter that's a function, so that if in the future we wanted to add functionality for something else with a modal we could do so relatively easily by exporting it. Closes #96 

Screenshot: 

![image](https://user-images.githubusercontent.com/47245900/94696339-45fc7b00-037a-11eb-99a6-80a975dcf31e.png)
