### PR TITLE
Also force the delegates in motions dropdowns to be present

### DIFF
--- a/src/components/Committee.tsx
+++ b/src/components/Committee.tsx
@@ -26,7 +26,7 @@ import { CommitteeShareHint } from './ShareHint';
 import Notifications from './Notifications';
 import { putResolution } from '../actions/resolution-actions';
 import ConnectionStatus from './ConnectionStatus';
-import { membersToOptions } from '../utils';
+import { membersToOptions, membersToPresentOptions } from '../utils';
 import { fieldHandler } from '../actions/handlers';
 import { MemberOption } from '../constants';
 import { putStrawpoll } from '../actions/strawpoll-actions';
@@ -35,6 +35,14 @@ import Strawpoll, { DEFAULT_STRAWPOLL, StrawpollID, StrawpollData } from './Stra
 export function recoverMemberOptions(committee?: CommitteeData): MemberOption[] {
   if (committee) {
     return membersToOptions(committee.members);
+  } else {
+    return [];
+  }
+}
+
+export function recoverPresentMemberOptions(committee?: CommitteeData): MemberOption[] {
+  if (committee) {
+    return membersToPresentOptions(committee.members);
   } else {
     return [];
   }

--- a/src/components/Motions.tsx
+++ b/src/components/Motions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import firebase from 'firebase/app';
-import { CommitteeData, CommitteeID, DEFAULT_COMMITTEE, recoverCaucus, recoverResolution, recoverMemberOptions } from './Committee';
+import { CommitteeData, CommitteeID, DEFAULT_COMMITTEE, recoverCaucus, recoverResolution, recoverPresentMemberOptions } from './Committee';
 import { RouteComponentProps } from 'react-router';
 import { Icon, Button, Card, Form, Message, Flag, Label, 
   Container, Divider } from 'semantic-ui-react';
@@ -723,7 +723,7 @@ export default class Motions extends React.Component<Props, State> {
       </Form.Group>
     );
 
-    const memberOptions = recoverMemberOptions(this.state.committee);
+    const memberOptions = recoverPresentMemberOptions(this.state.committee);
 
     const proposerTree = (
       <Form.Dropdown

--- a/src/components/caucus/CaucusQueuer.tsx
+++ b/src/components/caucus/CaucusQueuer.tsx
@@ -7,7 +7,7 @@ import { Segment, Button, Form, DropdownProps, Label } from 'semantic-ui-react';
 import { TimerSetter, Unit } from '../TimerSetter';
 import { SpeakerEvent, Stance } from '..//caucus/SpeakerFeed';
 import { checkboxHandler, validatedNumberFieldHandler, dropdownHandler } from '../../actions/handlers';
-import { presentMembersToOptions } from '../../utils';
+import { membersToPresentOptions } from '../../utils';
 import { Dictionary } from '../../types';
 
 interface Props {
@@ -19,6 +19,7 @@ interface Props {
 export default function CaucusQueuer(props: Props) {
   const { members, caucus, caucusFref } = props;
   const [queueMember, setQueueMember] = React.useState<MemberOption | undefined>(undefined);
+  const memberOptions = membersToPresentOptions(members);
 
   const setStance = (stance: Stance) => () => {
     const { caucus } = props;
@@ -37,13 +38,9 @@ export default function CaucusQueuer(props: Props) {
   }
 
   const setMember = (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps): void => {
-    const { members } = props;
-    const memberOptions = presentMembersToOptions(members);
-
     setQueueMember(memberOptions.filter(c => c.value === data.value)[0]);
   }
 
-  const memberOptions = presentMembersToOptions(members);
   const duration = recoverDuration(caucus);
   const disableButtons = !queueMember || !duration;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export function membersToOptions(members: Dictionary<MemberID, MemberData> | und
   return _.sortBy(options, (option: MemberOption) => option.text);
 }
 
-export function presentMembersToOptions(members: Dictionary<MemberID, MemberData> | undefined): MemberOption[] {
+export function membersToPresentOptions(members: Dictionary<MemberID, MemberData> | undefined): MemberOption[] {
   const options = objectToList(members || {})
     .filter(x => x.present)
     .map(x => nameToMemberOption(x.name));


### PR DESCRIPTION
I considered whether we want this member filtering everywhere (and did some refactoring for it).

I realised, no, we probably don't want that. Motions and caucus queuing are very "present", aka they typically result from a member being in the room, and only make sense if a member is in the room. But a director could feasibly upload an old amendment or resolution from someone the day before, and would like to tweak those. And we're also comfortable with them digging through some longass dropdown for those options, but for motions and caucuses, not so much. 