### PR TITLE
Update the copy in the header and homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,10 +36,10 @@
 
     <meta name="author" content="Max Bo">
 
-    <meta name="description" content="Muncoordinated is a collaborative browser-based Model UN committee management software suite.
-     It's also free and open-source, with a comprehensive feature set and a director-first user interface.">
-    <meta property="og:description" content="Muncoordinated is a collaborative browser-based Model UN committee management software suite.
-     It's also free and open-source, with a comprehensive feature set and a director-first user interface.">
+    <meta name="description" content="Model UN committee management software that lets directors AND delegates participate.
+      Muncoordinated lets you instantly see when your delegates upload files, add themselves to speaker lists, create amendments & vote on motions or strawpolls." />
+    <meta name="og:description" content="Model UN committee management software that lets directors AND delegates participate.
+      Muncoordinated lets you instantly see when your delegates upload files, add themselves to speaker lists, create amendments & vote on motions or strawpolls." />
 
   </head>
   <body>

--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -44,14 +44,16 @@ const HomepageHeading = ({ mobile }: HomepageHeadingProps) => (
     />
     <Header
       as="h2"
-      content="The collaborative browser-based Model UN committee management app"
       inverted
       style={{
         fontSize: mobile ? '1.5em' : '1.7em',
         fontWeight: 'normal',
         marginTop: mobile ? '0.5em' : '1.5em',
       }}
-    />
+    >
+      The collaborative Model UN committee management app.
+      For directors <b>and</b> delgates.
+    </Header>
     <br />
     <Button as="a" primary size="huge" href="/onboard" onClick={logClickCreateACommitteeButton}>
       Create a committee
@@ -238,15 +240,12 @@ export default class Homepage extends React.Component<{}, {
           <Grid container stackable verticalAlign="middle">
             <Grid.Row>
               <Grid.Column width={8}>
-                <Header as="h3" style={{ fontSize: '2em' }}>Collaborative</Header>
+                <Header as="h3" style={{ fontSize: '2em' }}>Collaborative &amp; remote friendly</Header>
                 <p style={{ fontSize: '1.33em' }}>
-                  Using a shareable link, multiple directors can run the committee at once. Delegates can also add themselves to speaker's lists, propose resolution amendments and upload files.<br />
+                  Using a shareable link, multiple directors can run the committee at once. Delegates can also add themselves to speaker's lists, propose resolution amendments, upload files, &amp; vote on strawpolls or motions.<br />
                 </p>
                 <p style={{ fontSize: '1.33em' }}>
                   Everyone will see all updates in real-time, without needing to refresh the page. It's like Google Docs, but for MUN.
-                </p>
-                <p style={{ fontSize: '1.33em' }}>
-                 We recommend pairing Muncoordinated with <a href="https://classroom.google.com">Google Classroom</a>, which allows you to share files, links, Google docs and strawpolls.
                 </p>
                 <Header as="h3" style={{ fontSize: '2em' }}>Cloud based</Header>
                 <p style={{ fontSize: '1.33em' }}>


### PR DESCRIPTION
The motivation for this is:

![image](https://user-images.githubusercontent.com/5368490/97432653-67985480-1970-11eb-8d74-b1a99a9d3c84.png)


Obviously I've screwed up my SEO for `mun software` a bit. Hopefully this rectifies it slightly. 