### PR TITLE
Make it clear that you can still use the app without a template

### DIFF
--- a/cypress/integration/onboard.spec.js
+++ b/cypress/integration/onboard.spec.js
@@ -46,7 +46,7 @@ describe('Run through creating a new committee', function () {
       .should('have.value', CONFERENCE)
 
     cy.get('div')
-      .contains('Template for committee')
+      .contains('Template to skip manual member creation (optional)')
       .type(TEMPLATE + '{enter}')
       .contains(TEMPLATE)
 

--- a/src/components/Onboard.tsx
+++ b/src/components/Onboard.tsx
@@ -162,7 +162,7 @@ export default class Onboard extends React.Component<Props, State> {
               search
               clearable
               selection
-              placeholder="Template for committee"
+              placeholder="Template to skip manual member creation (optional)"
               options={Object.values(CommitteeTemplate).map(makeDropdownOption)}
               onChange={this.onChangeTemplateDropdown}
             />


### PR DESCRIPTION
I'm worried that new users might click the dropdown, not see the type of committee they need to create, and churn. A better placeholder here makes it clear that you can still use and set up the app without this option.

It is also important to add more templates so that the risk of churn goes down even further. 