### PR TITLE
Add message to clarify need for account creation email. Closes #105

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -212,6 +212,8 @@ export class Login extends React.Component<Props, State> {
   renderNotice = () => {
     const list = [
       'Login to access your previously created committees, or to create a new committee',
+      'Create an account with an email and password',
+      'Note that the email is only used to reset passwords and may be fake if you value your privacy (no need to confirm account creation via email)',
       'Multiple directors may use the same account concurrently from different computers - use a password you\'re willing to share'
     ];
 


### PR DESCRIPTION
Maybe this could be worded better so that us saying "if you value your privacy" doesn't imply that we're violating their privacy otherwise. Closes #105.