### PR TITLE
Add misc. margins and whitespace

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -402,7 +402,7 @@ export default class Admin extends React.Component<Props, State> {
     ];
 
     return (
-      <Container text style={{ padding: '1em 0em' }}>
+      <Container text style={{ padding: '1em 0em 1.5em' }}>
         <Tab panes={panes} />
       </Container>
     );

--- a/src/components/Caucus.tsx
+++ b/src/components/Caucus.tsx
@@ -275,7 +275,7 @@ export default class Caucus extends React.Component<Props, State> {
     );
 
     return (
-      <Container>
+      <Container style={{ 'padding-bottom': '2em' }}>
         <Grid columns="equal" stackable>
           {header}
           {body}
@@ -292,7 +292,7 @@ export default class Caucus extends React.Component<Props, State> {
 
     if (!loading && !caucus) {
       return (
-        <Container text>
+        <Container text style={{ 'padding-bottom': '2em' }}>
           <NotFound item="caucus" id={caucusID} />
         </Container>
       );

--- a/src/components/Files.tsx
+++ b/src/components/Files.tsx
@@ -630,6 +630,7 @@ export default class Files extends React.Component<Props, State> {
           menu={{ attached: true, tabular: false }}
           panes={panes} 
         />
+        <div>&nbsp;</div> {/* Whitespace */}
         {this.renderFilter()}
         <Feed size="large">
           {committee ? Object.keys(files).reverse()

--- a/src/components/Resolution.tsx
+++ b/src/components/Resolution.tsx
@@ -798,7 +798,7 @@ export default class Resolution extends React.Component<Props, State> {
     ];
 
     return (
-      <Container>
+      <Container style={{ 'padding-bottom': '2em' }}>
         <Grid columns="equal" stackable>
           <Grid.Row>
             <Grid.Column>
@@ -827,7 +827,7 @@ export default class Resolution extends React.Component<Props, State> {
 
     if (!loading && !resolution) {
       return (
-        <Container text>
+        <Container text style={{ 'padding-bottom': '2em' }}>
           <NotFound item="resolution" id={resolutionID} />
         </Container>
       );

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -142,7 +142,7 @@ export default class Stats extends React.Component<Props, State> {
     });
 
     return (
-      <Container text style={{ padding: '1em 0em' }}>
+      <Container text style={{ padding: '1em 0em 1.5em' }}>
         <Table compact celled definition>
           <Table.Header>
             <Table.Row>


### PR DESCRIPTION
Adding margins to the bottom of miscellaneous pages (good for mobile users, however small % of the users they may be). And added whitespace a tab in resolutions. 

Example of margins:

<img src="https://user-images.githubusercontent.com/47245900/98468080-8d511380-2224-11eb-880a-42dc74cd0d7f.png" width=275> vs <img src="https://user-images.githubusercontent.com/47245900/98468023-567afd80-2224-11eb-8b32-0d6272bd5054.png" width=275>

Of margin:

<img src="https://user-images.githubusercontent.com/47245900/98468128-cab5a100-2224-11eb-9cc1-148d5cf85e6a.png" width=275> vs  <img src="https://user-images.githubusercontent.com/47245900/98468138-d4d79f80-2224-11eb-87c8-94a7716cba63.png" width=275>
