### PR TITLE
Add placeholder for SpeakerFeedEntry queue

### DIFF
--- a/src/components/caucus/SpeakerFeed.tsx
+++ b/src/components/caucus/SpeakerFeed.tsx
@@ -196,6 +196,7 @@ export const SpeakerFeed = (props: {
               size="large" 
             >
               {eventItems}
+              {provided.placeholder}
             </Feed>
           </div>
         }


### PR DESCRIPTION
Currently, when speakers are being dragged in the caucus queue, the size of the list collapses. It's possible to have a placeholder (read `Droppable` [documentation](https://github.com/atlassian/react-beautiful-dnd/blob/master/docs/api/droppable.md#1-provided-droppableprovided)) to prevent this from happening; this PR implements this. 

There's a still a bit of space added, which I couldn't figure out immediately how to fix but this solution is certainly preferable to what's happening now.

Demo (first part of the gif is what happens with the current setup, second is with what this PR implements:

![draggable](https://user-images.githubusercontent.com/47245900/121772479-eddc7080-cbb8-11eb-9fa6-969df2bd7640.gif)
