### PR TITLE
Add drag handle to SpeakerFeedEntry

### DIFF
--- a/src/components/caucus/SpeakerFeed.tsx
+++ b/src/components/caucus/SpeakerFeed.tsx
@@ -106,9 +106,11 @@ export class SpeakerFeedEntry extends React.PureComponent<{
       <div
         className="event" // XXX: quite possibly the most bullshit hack known to man
         ref={draggableProvided.innerRef}
-          {...draggableProvided.dragHandleProps}
           {...draggableProvided.draggableProps}>
             {this.renderContent()}
+            <div {...draggableProvided.dragHandleProps}
+                style={{ paddingLeft: '120px'}
+            }> ⠿ </div>
       </div>
     ) : <FeedEvent>
       {this.renderContent()}


### PR DESCRIPTION
Adds a drag handle to `SpeakerFeedEntry`. Closes #123 

Demo (with the #158 changes):

![123](https://user-images.githubusercontent.com/47245900/121774326-5e898a00-cbc5-11eb-8c84-616e744bfdf7.gif)
