### PR TITLE
Use realClick() instead of native Cypress click()

### DIFF
--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/admin.spec.js
+++ b/cypress/integration/admin.spec.js
@@ -1,4 +1,5 @@
 import { purge, SANDBOX, invokeModalAndLogin } from './utils'
+import "cypress-real-events/support";
 
 const SELECT_MEMBER = '.adder__dropdown--select-member'
 const SELECT_RANK = '.adder__dropdown--select-rank'
@@ -8,63 +9,63 @@ const ADD_MEMBER = '.adder__button--add-member'
 const REMOVE_MEMBER = ".members__button--remove-member"
 
 function clickAddMember() {
-  cy.get(ADD_MEMBER).click()
+  cy.get(ADD_MEMBER).realClick()
   cy.get(ADD_MEMBER).should('be.disabled')
   cy.get(SELECT_MEMBER).should('have.class', 'error')
 }
 
 describe('Add members and checks that the thresholds are sensible', function () {
-    before(function() {
-      purge()
-      cy.visit(SANDBOX)
-    })
-
-    it('logs in to our test account', () => {
-      invokeModalAndLogin()
-    })
-
-    it('navs to the admin page', () => {
-      cy.contains('Setup').click()
-      cy.url().should('include', '/setup')
-      cy.wait(2000)
-    })
-
-    it('removes all pre-existing members', function () {
-      cy.get(REMOVE_MEMBER).click({ multiple: true })
-    })
-
-    it('adds Afghanistan', function () {
-      clickAddMember()
-      cy.get('table').should('contain', 'Afghanistan')
-    })
-
-    it('adds Bolivia', function () {
-      cy.get(SELECT_MEMBER).children('input').click().type('Bolivia{enter}')
-      cy.get(SELECT_RANK).children('input').click().type('Observer{enter}')
-
-      clickAddMember()
-
-      cy.get('table').should('contain', 'Bolivia')
-    })
-
-    it('adds China', function () {
-      cy.get(SELECT_MEMBER).children('input').click().type('China{enter}')
-      cy.get(SELECT_RANK).children('input').click().type('Veto{enter}')
-      cy.get(TOGGLE_VOTING).children('input').check({force: true})
-
-      clickAddMember()
-
-      cy.get('table').should('contain', 'China')
-    })
-
-    it('goes to the Thresholds page', function () {
-      cy.get('table').contains('Total').siblings().should('contain', '3')
-      cy.get('table').contains('Present').siblings().should('contain', '3')
-      cy.get('table').contains('Have voting rights').siblings().should('contain', '2')
-      cy.get('table').contains('Debate').siblings().should('contain', '1')
-      cy.get('table').contains('Procedural threshold').siblings().should('contain', '2')
-      cy.get('table').contains('Operative threshold').siblings().should('contain', '1')
-      cy.get('table').contains('Draft resolution').siblings().should('contain', '1')
-      cy.get('table').contains('Amendment').siblings().should('contain', '1')
-    })
+  before(function () {
+    purge()
+    cy.visit(SANDBOX)
   })
+
+  it('logs in to our test account', () => {
+    invokeModalAndLogin()
+  })
+
+  it('navs to the admin page', () => {
+    cy.contains('Setup').realClick()
+    cy.url().should('include', '/setup')
+    cy.wait(2000)
+  })
+
+  it('removes all pre-existing members', function () {
+    cy.get(REMOVE_MEMBER).click({ multiple: true })
+  })
+
+  it('adds Afghanistan', function () {
+    clickAddMember()
+    cy.get('table').should('contain', 'Afghanistan')
+  })
+
+  it('adds Bolivia', function () {
+    cy.get(SELECT_MEMBER).children('input').realClick().type('Bolivia{enter}')
+    cy.get(SELECT_RANK).children('input').realClick().type('Observer{enter}')
+
+    clickAddMember()
+
+    cy.get('table').should('contain', 'Bolivia')
+  })
+
+  it('adds China', function () {
+    cy.get(SELECT_MEMBER).children('input').realClick().type('China{enter}')
+    cy.get(SELECT_RANK).children('input').realClick().type('Veto{enter}')
+    cy.get(TOGGLE_VOTING).children('input').check({ force: true })
+
+    clickAddMember()
+
+    cy.get('table').should('contain', 'China')
+  })
+
+  it('goes to the Thresholds page', function () {
+    cy.get('table').eq(1).contains('Total').siblings().should('contain', '3')
+    cy.get('table').eq(1).contains('Present').siblings().should('contain', '3')
+    cy.get('table').eq(1).contains('Have voting rights').siblings().should('contain', '2')
+    cy.get('table').eq(1).contains('Debate').siblings().should('contain', '1')
+    cy.get('table').eq(1).contains('Procedural threshold').siblings().should('contain', '2')
+    cy.get('table').eq(1).contains('Operative threshold').siblings().should('contain', '1')
+    cy.get('table').eq(1).contains('Draft resolution').siblings().should('contain', '1')
+    cy.get('table').eq(1).contains('Amendment').siblings().should('contain', '1')
+  })
+})

--- a/cypress/integration/onboard.spec.js
+++ b/cypress/integration/onboard.spec.js
@@ -5,7 +5,7 @@ const TOPIC = 'Test topic'
 const CONFERENCE = 'Test conference'
 
 describe('Run through creating a new committee', function () {
-  before(function() {
+  before(function () {
     purge()
     cy.visit("/")
   })
@@ -79,6 +79,6 @@ describe('Run through creating a new committee', function () {
     cy.get('table').should('contain', 'United Kingdom')
 
     cy.contains('Thresholds').click()
-    cy.get('table').contains('Total').siblings().should('contain', '15')
+    cy.get('table').eq(1).contains('Total').siblings().should('contain', '15')
   })
 })

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "^16.8.2",
     "@types/react-helmet": "^6.1.1",
     "@types/react-router-dom": "^5.1.2",
+    "cypress-real-events": "^1.7.1",
     "file-saver": "^2.0.0-rc.3",
     "firebase": "^7.3.0",
     "lodash": "^4.17.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4821,6 +4821,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-real-events@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.1.tgz#8f430d67c29ea4f05b9c5b0311780120cbc9b935"
+  integrity sha512-/Bg15RgJ0SYsuXc6lPqH08x19z6j2vmhWN4wXfJqm3z8BTAFiK2MvipZPzxT8Z0jJP0q7kuniWrLIvz/i/8lCQ==
+
 cypress@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.6.1.tgz#4420957923879f60b7a5146ccbf81841a149b653"


### PR DESCRIPTION
I used a package called cypress-real-events which uses actual actions like clicks, hovers, etc. rather than Cypress's native methods like click().
This should potentially save you from force clicking the element every time a new element is added.
Thank you.