### PR TITLE
Side bar animation and button functionality

### DIFF
--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -167,8 +167,8 @@ class MobileContainer extends React.Component<MobileContainerProps, MobileContai
         <Sidebar.Pushable>
           <Sidebar as={Menu} animation="push" inverted vertical visible={sidebarOpened}>
             <Menu.Item as="a" active>Home</Menu.Item>
-            <Menu.Item as="a">Log in</Menu.Item>
-            <Menu.Item as="a">Sign up</Menu.Item>
+            <Menu.Item as="a" href="/onboard">Log in</Menu.Item>
+            <Menu.Item as="a" href="/onboard">Sign up</Menu.Item>
           </Sidebar>
 
           <Sidebar.Pusher dimmed={sidebarOpened} onClick={this.handlePusherClick} style={{ minHeight: '100vh' }}>

--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -165,7 +165,7 @@ class MobileContainer extends React.Component<MobileContainerProps, MobileContai
     return (
       <Responsive {...Responsive.onlyMobile}>
         <Sidebar.Pushable>
-          <Sidebar as={Menu} animation="uncover" inverted vertical visible={sidebarOpened}>
+          <Sidebar as={Menu} animation="push" inverted vertical visible={sidebarOpened}>
             <Menu.Item as="a" active>Home</Menu.Item>
             <Menu.Item as="a">Log in</Menu.Item>
             <Menu.Item as="a">Sign up</Menu.Item>


### PR DESCRIPTION
Currently the side bar animation on the home page stays behind while the animation plays 

> With animation uncover

https://user-images.githubusercontent.com/77178777/194733508-f148ea45-96d6-4a69-930a-8802f6a54dab.mp4

> With animation push

https://user-images.githubusercontent.com/77178777/194733580-85eccc89-fd7e-4274-a5f9-c2b6162d133e.mp4

I think switching the animation from "uncover" to "push" doesn't change the look too drastically and makes the animation look much cleaner. Also added proper links to the side bar buttons.