### PR TITLE
Fix homepage mobile layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,11 @@
+html,
 body {
   margin: 0;
   padding: 0;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+body {
   font-family: sans-serif;
 }

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createMedia } from '@artsy/fresnel';
 import {
   Button,
   Container,
@@ -17,6 +18,19 @@ import { logClickCreateACommitteeButton, logClickLogInButton, logClickSignupButt
 import Loading from '../components/Loading';
 import { ShareCapabilities } from '../components/share-hints';
 
+const HomepageMedia = createMedia({
+  breakpoints: {
+    mobile: 320,
+    tablet: 768,
+    computer: 992,
+    largeScreen: 1200,
+    widescreen: 1920,
+  },
+});
+
+const homepageMediaStyles = HomepageMedia.createMediaStyle();
+const { Media, MediaContextProvider } = HomepageMedia;
+
 interface HomepageHeadingProps {
   mobile: boolean;
 }
@@ -28,7 +42,7 @@ const REPO_LINK = 'https://github.com/MaxwellBo/Muncoordinated-2';
  * such things.
  */
 const HomepageHeading = ({ mobile }: HomepageHeadingProps) => (
-  <Container text>
+  <Container text style={{ maxWidth: '100%', padding: '0 1em' }}>
     <Header
       as="h1"
       content="Muncoordinated"
@@ -38,6 +52,8 @@ const HomepageHeading = ({ mobile }: HomepageHeadingProps) => (
         fontWeight: 'normal',
         marginBottom: 0,
         marginTop: mobile ? '1.5em' : '3em',
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
       }}
     />
     <Header
@@ -45,9 +61,11 @@ const HomepageHeading = ({ mobile }: HomepageHeadingProps) => (
       content="The collaborative browser-based Model UN committee management app"
       inverted
       style={{
-        fontSize: mobile ? '1.5em' : '1.7em',
+        fontSize: mobile ? '1.25em' : '1.7em',
         fontWeight: 'normal',
         marginTop: mobile ? '0.5em' : '1.5em',
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
       }}
     />
     <br />
@@ -98,7 +116,7 @@ class DesktopContainer extends React.Component<DesktopContainerProps, DesktopCon
       <>
       {/* @ts-ignore */}
         <Visibility once={false} onBottomPassed={this.showFixedMenu} onBottomPassedReverse={this.hideFixedMenu}>
-          <Segment inverted textAlign="center" style={{ minHeight: 700, padding: '1em 0em' }} vertical>
+          <Segment inverted textAlign="center" style={{ minHeight: 700, padding: '1em 0em', width: '100%' }} vertical>
             <Menu
               fixed={fixed ? 'top' : undefined}
               inverted={!fixed}
@@ -135,73 +153,85 @@ interface MobileContainerState {
   sidebarOpened: boolean;
 }
 
-// class MobileContainer extends React.Component<MobileContainerProps, MobileContainerState> {
-//   constructor(props: MobileContainerProps) {
-//     super(props);
+class MobileContainer extends React.Component<MobileContainerProps, MobileContainerState> {
+  constructor(props: MobileContainerProps) {
+    super(props);
 
-//     this.state = {
-//       sidebarOpened: false
-//     };
-//   }
+    this.state = {
+      sidebarOpened: false
+    };
+  }
 
-//   handlePusherClick = () => {
-//     const { sidebarOpened } = this.state;
+  handlePusherClick = () => {
+    const { sidebarOpened } = this.state;
 
-//     if (sidebarOpened) {
-//       this.setState({ sidebarOpened: false });
-//     }
-//   }
+    if (sidebarOpened) {
+      this.setState({ sidebarOpened: false });
+    }
+  }
 
-//   handleToggle = () => {
-//     this.setState({ sidebarOpened: !this.state.sidebarOpened });
-//   }
+  handleToggle = () => {
+    this.setState({ sidebarOpened: !this.state.sidebarOpened });
+  }
 
-//   render() {
-//     const { children } = this.props;
-//     const { sidebarOpened } = this.state;
+  render() {
+    const { children } = this.props;
+    const { sidebarOpened } = this.state;
 
-//     return (
-//       <>
-//         <Sidebar.Pushable>
-//           <Sidebar as={Menu} animation="push" inverted vertical visible={sidebarOpened}>
-//             <Menu.Item as="a" active>Home</Menu.Item>
-//             <Menu.Item as="a" href="/onboard">Log in</Menu.Item>
-//             <Menu.Item as="a" href="/onboard">Sign up</Menu.Item>
-//           </Sidebar>
+    return (
+      <>
+        <Sidebar.Pushable>
+          <Sidebar as={Menu} animation="push" inverted vertical visible={sidebarOpened}>
+            <Menu.Item as="a" active>Home</Menu.Item>
+            <Menu.Item as="a" href="/onboard" onClick={logClickLogInButton}>Log in</Menu.Item>
+            <Menu.Item as="a" href="/onboard" onClick={logClickSignupButton}>Sign up</Menu.Item>
+          </Sidebar>
 
-//           <Sidebar.Pusher dimmed={sidebarOpened} onClick={this.handlePusherClick} style={{ minHeight: '100vh' }}>
-//             <Segment inverted textAlign="center" style={{ minHeight: 350, padding: '1em 0em' }} vertical>
-//               <Container>
-//                 <Menu inverted pointing secondary size="large">
-//                   <Menu.Item onClick={this.handleToggle}>
-//                     <Icon name="sidebar" />
-//                   </Menu.Item>
-//                   <Menu.Item position="right">
-//                     <Button as="a" inverted href="/onboard" >Log in</Button>
-//                     <Button as="a" inverted href="/onboard" style={{ marginLeft: '0.5em' }}>Sign Up</Button>
-//                   </Menu.Item>
-//                 </Menu>
-//               </Container>
-//               <HomepageHeading mobile={true} />
-//             </Segment>
+          <Sidebar.Pusher dimmed={sidebarOpened} onClick={this.handlePusherClick} style={{ minHeight: '100vh' }}>
+            <Segment inverted textAlign="center" style={{ minHeight: 350, padding: '1em 0em', width: '100%' }} vertical>
+              <Container>
+                <Menu inverted pointing secondary size="large">
+                  <Menu.Item onClick={this.handleToggle}>
+                    <Icon name="sidebar" />
+                  </Menu.Item>
+                  <Menu.Item as="a" active>Home</Menu.Item>
+                  <Menu.Item position="right">
+                    <Button as="a" inverted size="small" href="/onboard" onClick={logClickLogInButton}>
+                      Log in
+                    </Button>
+                    <Button as="a" inverted primary size="small" href="/onboard" style={{ marginLeft: '0.5em' }} onClick={logClickSignupButton}>
+                      Sign up
+                    </Button>
+                  </Menu.Item>
+                </Menu>
+              </Container>
+              <HomepageHeading mobile={true} />
+            </Segment>
 
-//             {children}
-//           </Sidebar.Pusher>
-//         </Sidebar.Pushable>
-//         </> 
-//     );
-//   }
-// }
+            {children}
+          </Sidebar.Pusher>
+        </Sidebar.Pushable>
+      </>
+    );
+  }
+}
 
 interface ResponsiveContainerProps {
   children?: React.ReactNode;
 }
 
 const ResponsiveContainer = ({ children }: ResponsiveContainerProps) => (
-  <React.Fragment>
-    <DesktopContainer>{children}</DesktopContainer>
-    {/* <MobileContainer>{children}</MobileContainer> */}
-  </React.Fragment>
+  <>
+    <style>{homepageMediaStyles}</style>
+    <MediaContextProvider>
+      <Media greaterThanOrEqual="tablet">
+        <DesktopContainer>{children}</DesktopContainer>
+      </Media>
+      <Media at="mobile">
+        <MobileContainer>{children}</MobileContainer>
+      </Media>
+    </MediaContextProvider>
+  </>
 );
 
 export default class Homepage extends React.Component<{}, { 
@@ -231,8 +261,9 @@ export default class Homepage extends React.Component<{}, {
   render() {
     return (
       <ResponsiveContainer>
-        <Segment style={{ padding: '3em 0em' }} vertical>
-          <Grid container stackable verticalAlign="middle">
+        <Segment style={{ padding: '3em 0em', width: '100%' }} vertical>
+          <Container>
+          <Grid stackable verticalAlign="middle">
             <Grid.Row>
               <Grid.Column width={8}>
                 <Header as="h3" style={{ fontSize: '2em' }}>Collaborative</Header>
@@ -259,7 +290,7 @@ export default class Homepage extends React.Component<{}, {
                 <Image
                   bordered
                   rounded
-                  size="massive"
+                  fluid
                   src="/promo.png"
                 />
               </Grid.Column>
@@ -299,6 +330,7 @@ export default class Homepage extends React.Component<{}, {
               </Grid.Column>
             </Grid.Row>
           </Grid>
+          </Container>
         </Segment>
         <Segment inverted vertical style={{ padding: '5em 0em' }}>
           <Container>


### PR DESCRIPTION
## Summary
- Re-enable the mobile homepage layout (it was commented out), using `@artsy/fresnel` breakpoints consistent with the committee pages
- Use mobile-sized hero typography and a compact nav on small screens instead of the desktop 4em title that overflowed the viewport
- Prevent horizontal overflow via fluid promo imagery, a contained content grid, and `overflow-x: hidden` on the document root

## Test plan
- [ ] Open https://muncoordinated.io/ (or local dev) on a phone or Chrome DevTools mobile viewport (~375px wide)
- [ ] Confirm the hero shows the full "Muncoordinated" title without horizontal scroll
- [ ] Confirm the dark hero background spans the full viewport width
- [ ] Confirm nav (hamburger, Home, Log in, Sign up) fits without clipping
- [ ] Scroll through Collaborative / feature sections; images and text stay within the viewport
- [ ] Verify desktop layout at tablet width and above is unchanged


Made with [Cursor](https://cursor.com)