### PR TITLE
Fix committee viewport padding

### DIFF
--- a/src/pages/Committee.tsx
+++ b/src/pages/Committee.tsx
@@ -89,7 +89,7 @@ class DesktopContainer extends React.Component<DesktopContainerProps, DesktopCon
       <>
       <style>{mediaStyles}</style>
       <MediaContextProvider>
-          <Segment as={Media} basic greaterThanOrEqual="tablet" style={{padding: 0}}>
+          <Segment as={Media} basic greaterThanOrEqual="tablet" style={{padding: 0, margin: 0}}>
             <Menu fluid size="small">
               {menu}
             </Menu>
@@ -130,7 +130,7 @@ class MobileContainer extends React.Component<MobileContainerProps, MobileContai
     <>
     <style>{mediaStyles}</style>
     <MediaContextProvider>
-      <Segment as={Media} basic at="mobile">
+      <Segment as={Media} basic at="mobile" style={{padding: 0, margin: 0}}>
         <Sidebar.Pushable>
           <Sidebar as={Menu} animation="uncover" stackable visible={sidebarOpened}>
             {menu}


### PR DESCRIPTION
## Summary
- Remove default Semantic UI Segment padding and margin from the committee responsive wrappers.
- Keep mobile and desktop committee layouts flush with the viewport edge.

## Test plan
- yarn build


Made with [Cursor](https://cursor.com)