### PR TITLE
docs: document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,14 @@
 - To inspect the app manually against local Firebase services, run `pnpm emulators` in one terminal and `VITE_USE_FIREBASE_EMULATORS=true pnpm start` in another.
 - The emulator suite requires Java 21 or newer. The scripts automatically prefer a Homebrew OpenJDK 21 install on macOS when available.
 - Do not point Cypress integration tests at the production Firebase project. Seed test users and database state through `cypress/plugins/firebaseEmulator.js`.
+
+## Cursor Cloud specific instructions
+
+- Node 22, `pnpm`, and OpenJDK 21 are preinstalled; the update script only runs `pnpm install`. Java 21 satisfies the emulator suite requirement (the macOS Homebrew JDK lookup in `scripts/firebase-emulators.mjs` is a no-op here).
+- Scripts/commands are defined in `package.json`. Notable gotchas:
+  - `pnpm test` runs Vitest in watch mode (never exits). For a one-shot run use `pnpm exec vitest run`.
+  - There is no `lint` script. Typecheck with `pnpm exec tsc --noEmit` (production `pnpm build` runs `tsc && vite build`).
+- The dev server (`pnpm start`, Vite) binds to `localhost` only, so `curl http://127.0.0.1:5173` fails while `curl http://localhost:5173` works. Pass `--host` to expose it on other interfaces.
+- The Firebase web config in `src/App.tsx` is a hardcoded public config, so no secrets are needed. By default the app talks to the real `muncoordinated` Firebase project; set `VITE_USE_FIREBASE_EMULATORS=true` to wire it to the local emulators (Auth 9099, DB 9000, Storage 9199, UI 4000). Prefer emulators for local testing to avoid writing to production.
+- Emulator startup logs `gcp-metadata` `ECONNRESET` and "Unable to fetch the CLI MOTD" warnings due to restricted egress; these are non-fatal and the emulators still start.
+- Cypress e2e (`pnpm test:e2e`, `pnpm cypress:run`) is blocked in this environment: the Cypress binary is not downloaded by `pnpm install`, and fetching it from `download.cypress.io` is blocked by network egress. Unit tests and manual/emulator testing work without it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for Muncoordinated in Cursor Cloud, and records durable, non-obvious setup notes in `AGENTS.md`.

The only code change is documentation (`AGENTS.md`). Dependency refresh is handled by the update script (`pnpm install`).

## Environment verification

- ✅ `pnpm install` — dependencies installed (Node 22, pnpm 10.33, OpenJDK 21 preinstalled)
- ✅ `pnpm exec tsc --noEmit` — typecheck passes (no `lint` script exists)
- ✅ `pnpm exec vitest run` — unit tests pass (1 file, 1 test)
- ✅ `pnpm emulators` — Firebase Auth/DB/Storage emulators start
- ✅ `VITE_USE_FIREBASE_EMULATORS=true pnpm start` — dev server runs against emulators; signed up a new account and created a committee end-to-end
- ⚠️ `pnpm test:e2e` (Cypress) — blocked: the Cypress binary is not fetched by `pnpm install` and `download.cypress.io` is blocked by network egress

## AGENTS.md notes added

- `pnpm test` runs Vitest in watch mode; use `pnpm exec vitest run` for one-shot
- No `lint` script; typecheck via `pnpm exec tsc --noEmit`
- Vite binds to `localhost` only (`curl 127.0.0.1:5173` fails, `localhost:5173` works)
- Firebase web config is hardcoded/public — no secrets needed; use `VITE_USE_FIREBASE_EMULATORS=true` for local emulators
- Emulator `gcp-metadata`/MOTD warnings are non-fatal
- Cypress e2e blocked by egress

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6689b42b-0454-4fb5-8f57-1db38fdfeb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6689b42b-0454-4fb5-8f57-1db38fdfeb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

